### PR TITLE
fix: Align react-dom version with react to fix white screen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@ updates:
       day: "saturday"
       time: "07:00"
       timezone: "Asia/Tokyo"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "recall",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recall",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "lucide-react": "^1.8.0",
         "react": "^19.2.5",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.5"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.10.1",
@@ -1032,15 +1032,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.5"
       }
     },
     "node_modules/rolldown": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@tauri-apps/api": "^2.10.1",
     "lucide-react": "^1.8.0",
     "react": "^19.2.5",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.5"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.10.1",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,7 +93,7 @@ fn save_entry(entry: &ClipboardEntry) -> std::io::Result<()> {
         history.extend(pinned);
 
         // Sort by timestamp to maintain chronological order
-        history.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        history.sort_by_key(|a| a.timestamp);
     }
 
     save_history(&history)


### PR DESCRIPTION
## Summary
Fix white screen on launch caused by `react` and `react-dom` version mismatch after dependabot updates.

## Context
After merging dependabot PRs that bumped `react` to `^19.2.5`, the app started showing a blank white screen on launch. The root cause was that `react-dom` remained at `^19.2.4` in `package.json`, resulting in `react@19.2.5` and `react-dom@19.2.4` being installed together. React 19 requires `react` and `react-dom` versions to match exactly; a mismatch causes a runtime error that prevents rendering.

## Changes
- Updated `react-dom` from `^19.2.4` to `^19.2.5` in `package.json` to align with `react`
- Updated `package-lock.json` accordingly

## Testing
```bash
npm install
npm run build        # Should complete without errors
npm run tauri dev    # App should render correctly (no white screen)
```
