### PR TITLE
Group tauri-related updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
       day: "saturday"
       time: "07:00"
       timezone: "Asia/Tokyo"
+    groups:
+      tauri:
+        patterns:
+          - "tauri"
+          - "tauri-*"
+          - "tauri-plugin-*"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -22,6 +28,9 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+      tauri:
+        patterns:
+          - "@tauri-apps/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Group `tauri`, `tauri-*`, `tauri-plugin-*` cargo crates into a single grouped PR
- Group `@tauri-apps/*` npm packages into a single grouped PR
- Reduces the chance of Tauri Rust crate / NPM package version mismatch failures (e.g. PR #90 build error: `tauri (v2.11.1) : @tauri-apps/api (v2.10.1)`)

## Notes
- Dependabot does not support cross-ecosystem grouping, so cargo and npm will still produce separate PRs — but each side will be internally aligned.

## Test plan
- [ ] Wait for next scheduled Dependabot run (Saturday 07:00 JST) and verify tauri-related updates are grouped per ecosystem