### PR TITLE
Add cooldown periods to Dependabot to reduce supply chain attack risk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       day: "saturday"
       time: "07:00"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -15,6 +20,11 @@ updates:
       day: "saturday"
       time: "07:00"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
     groups:
       react:
         patterns:
@@ -30,3 +40,8 @@ updates:
       day: "saturday"
       time: "07:00"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7


### PR DESCRIPTION
## Summary
- Add `cooldown` config to all Dependabot ecosystems (cargo, npm, github-actions)
- Waits before opening PRs for newly released versions, giving the community time to surface malicious or broken releases (e.g. recent npm supply chain attacks like shai-hulud / s1ngularity)

## Cooldown values
| Update type | Wait |
|---|---|
| patch / default | 7 days |
| minor | 14 days |
| major | 30 days |

Rationale: majors are more disruptive and warrant longer observation, while patches are usually safe and often contain security fixes — so we take those sooner.

## Test plan
- [ ] Dependabot config syntax is accepted by GitHub (Insights → Dependency graph → Dependabot shows no parse errors)
- [ ] Subsequent Dependabot PRs respect the cooldown window