### PR TITLE
Remove unsupported semver-* cooldown keys from github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,3 @@ updates:
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7


### PR DESCRIPTION
## Summary
Fixes a Dependabot config parse error introduced in #101.

Dependabot reported:
> The property '#/updates/2/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
> The property '#/updates/2/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
> The property '#/updates/2/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.

The `github-actions` ecosystem only supports `cooldown.default-days`; the per-semver keys are valid for `cargo` and `npm` only. This PR drops the unsupported keys for the github-actions entry while keeping `default-days: 7`.

## Test plan
- [ ] Dependabot no longer reports the parse error on this branch