### PR TITLE
Ignore Enter and navigation keys during IME composition

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,12 @@ function App() {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      // Ignore keystrokes emitted while an IME composition is active (src/App.tsx).
+      // When converting Japanese with the IME, the Enter that confirms the
+      // conversion would otherwise be treated as "copy & close". keyCode 229 is
+      // the legacy fallback for browsers that don't set isComposing reliably.
+      if (e.isComposing || e.keyCode === 229) return;
+
       // Whether focus is in the search input (src/App.tsx). When typing in the
       // search box, j/k should be entered as text instead of navigating.
       const inSearch = document.activeElement === searchInputRef.current;


### PR DESCRIPTION
## Problem

When using the search filter with a Japanese IME, pressing Enter to confirm a kanji conversion also triggered the global key handler's "copy & close" behavior. The window closed before the user could choose among multiple conversion candidates.

## Fix

Added a guard at the top of `handleKeyDown` (src/App.tsx) to ignore keystrokes emitted while an IME composition is active:

```ts
if (e.isComposing || e.keyCode === 229) return;
```

- `isComposing` is the primary check; `keyCode === 229` is a legacy fallback for browsers that don't set `isComposing` reliably.
- During composition, Enter now only confirms the conversion. After confirming, pressing Enter again copies the selected entry as before.

## Verification

- `npx tsc --noEmit` passes.