### PR TITLE
Add confirmation dialog before clearing all history

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ function App() {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [query, setQuery] = useState<string>("");
   const [version, setVersion] = useState<string>("");
+  const [showClearConfirm, setShowClearConfirm] = useState<boolean>(false);
   const [theme, setTheme] = useState<Theme>(() => {
     return (localStorage.getItem("theme") as Theme) || "system";
   });
@@ -91,6 +92,20 @@ function App() {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      // While the clear-all confirmation dialog is open (src/App.tsx), Enter
+      // confirms the deletion and Escape cancels it; all list navigation keys
+      // are suppressed so they don't act on the hidden list underneath.
+      if (showClearConfirm) {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          confirmClearAll();
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          cancelClearAll();
+        }
+        return;
+      }
+
       // Ignore keystrokes emitted while an IME composition is active (src/App.tsx).
       // When converting Japanese with the IME, the Enter that confirms the
       // conversion would otherwise be treated as "copy & close". keyCode 229 is
@@ -146,7 +161,7 @@ function App() {
           break;
       }
     },
-    [filteredHistory, selectedIndex, scrollToSelected]
+    [filteredHistory, selectedIndex, scrollToSelected, showClearConfirm]
   );
 
   useEffect(() => {
@@ -252,14 +267,31 @@ function App() {
     }
   };
 
-  const handleClearAll = async () => {
+  // Opens the clear-all confirmation dialog in src/App.tsx (settings-row trash
+  // button). The actual deletion is deferred to confirmClearAll so an accidental
+  // click no longer wipes history immediately.
+  const handleClearAll = () => {
+    setShowClearConfirm(true);
+  };
+
+  // Performs the actual history deletion in src/App.tsx after the user confirms
+  // in the dialog opened by handleClearAll. Invokes the clear_all_history
+  // command, then reloads the list and closes the dialog.
+  const confirmClearAll = async () => {
     try {
       await invoke("clear_all_history");
       loadHistory();
       setSelectedIndex(0);
     } catch (error) {
       console.error("Failed to clear history:", error);
+    } finally {
+      setShowClearConfirm(false);
     }
+  };
+
+  // Cancels the clear-all confirmation dialog in src/App.tsx without deleting.
+  const cancelClearAll = () => {
+    setShowClearConfirm(false);
   };
 
   return (
@@ -335,6 +367,31 @@ function App() {
           ))
         )}
       </div>
+
+      {showClearConfirm && (
+        <div className="confirm-overlay" onClick={cancelClearAll}>
+          <div
+            className="confirm-dialog"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="confirm-message">
+              ピン留め以外の履歴をすべて削除しますか？
+            </p>
+            <div className="confirm-actions">
+              <button
+                className="confirm-cancel"
+                onClick={cancelClearAll}
+                autoFocus
+              >
+                キャンセル
+              </button>
+              <button className="confirm-delete" onClick={confirmClearAll}>
+                削除
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -375,7 +375,7 @@ function App() {
             onClick={(e) => e.stopPropagation()}
           >
             <p className="confirm-message">
-              ピン留め以外の履歴をすべて削除しますか？
+              Clear all unpinned history?
             </p>
             <div className="confirm-actions">
               <button
@@ -383,10 +383,10 @@ function App() {
                 onClick={cancelClearAll}
                 autoFocus
               >
-                キャンセル
+                Cancel
               </button>
               <button className="confirm-delete" onClick={confirmClearAll}>
-                削除
+                Delete
               </button>
             </div>
           </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -519,3 +519,103 @@ body[data-theme="dark"] .theme-toggle:hover {
   border-color: #0a84ff;
   color: #0a84ff;
 }
+
+/* Clear-all confirmation dialog */
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.35);
+  z-index: 1000;
+}
+
+.confirm-dialog {
+  width: 80%;
+  max-width: 260px;
+  padding: 16px;
+  border-radius: 10px;
+  background-color: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+.confirm-message {
+  font-size: 12px;
+  color: #1d1d1f;
+  text-align: center;
+  margin-bottom: 14px;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+}
+
+.confirm-actions button {
+  flex: 1;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.confirm-cancel {
+  background-color: #e5e5ea;
+  color: #1d1d1f;
+}
+
+.confirm-cancel:hover {
+  background-color: #d2d2d7;
+}
+
+.confirm-delete {
+  background-color: #ff3b30;
+  color: #fff;
+}
+
+.confirm-delete:hover {
+  background-color: #d63028;
+}
+
+/* Dark mode - confirmation dialog (auto) */
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"]) .confirm-dialog {
+    background-color: #2c2c2e;
+  }
+
+  body:not([data-theme="light"]) .confirm-message {
+    color: #f5f5f7;
+  }
+
+  body:not([data-theme="light"]) .confirm-cancel {
+    background-color: #3a3a3c;
+    color: #f5f5f7;
+  }
+
+  body:not([data-theme="light"]) .confirm-cancel:hover {
+    background-color: #48484a;
+  }
+}
+
+/* Dark mode - confirmation dialog (forced) */
+body[data-theme="dark"] .confirm-dialog {
+  background-color: #2c2c2e;
+}
+
+body[data-theme="dark"] .confirm-message {
+  color: #f5f5f7;
+}
+
+body[data-theme="dark"] .confirm-cancel {
+  background-color: #3a3a3c;
+  color: #f5f5f7;
+}
+
+body[data-theme="dark"] .confirm-cancel:hover {
+  background-color: #48484a;
+}


### PR DESCRIPTION
## Summary

The clear-all button (trash icon in the settings row) previously called `clear_all_history` immediately on click, so a single accidental click wiped all unpinned clipboard history with no undo.

This adds a confirmation step: clicking the button now opens an in-app modal, and the history is only cleared after the user explicitly confirms.

## Changes

- `src/App.tsx`
  - `handleClearAll` now only opens the confirmation dialog (`showClearConfirm` state).
  - New `confirmClearAll` performs the actual `clear_all_history` invoke + reload, then closes the dialog; `cancelClearAll` closes without deleting.
  - Added the confirmation modal (overlay + dialog with キャンセル / 削除 buttons). Clicking the overlay or キャンセル cancels.
  - Keyboard support while the dialog is open: **Enter** confirms, **Escape** cancels, and list navigation (j/k/arrows/Enter-to-copy) is suppressed.
- `src/styles.css`
  - Styles for the overlay/dialog/buttons, with auto (`prefers-color-scheme`) and forced dark-mode variants.

## Notes

A custom in-app modal is used instead of the native `window.confirm()` on purpose: the window auto-hides on focus loss, and a native dialog would risk triggering that and dismissing everything.

Closes #120